### PR TITLE
Fix by-value self-inclusion in C++

### DIFF
--- a/thrift/crossdock/tracetest.thrift
+++ b/thrift/crossdock/tracetest.thrift
@@ -25,7 +25,7 @@ struct Downstream {
     3: required string host
     4: required string port
     5: required Transport transport
-    6: optional Downstream downstream
+    6: optional Downstream &downstream
 }
 
 struct StartTraceRequest {

--- a/thrift/crossdock/tracetest.thrift
+++ b/thrift/crossdock/tracetest.thrift
@@ -54,7 +54,7 @@ struct ObservedSpan {
  */
 struct TraceResponse {
     1: optional ObservedSpan span
-    2: optional TraceResponse downstream
+    2: optional TraceResponse &downstream
     3: required string notImplementedError
 }
 


### PR DESCRIPTION
This IDL is fine for languages where everything is by-reference. But for C++, it tries to embed a class by-value into its self, which cannot succeed, and results in compilation failure. See https://github.com/jaegertracing/jaeger-idl/issues/35

This has been worked around by patching the IDL-generated code; see https://github.com/jaegertracing/cpp-client/issues/45 .

It turns out we can just tell Thrift to include the optional member by-reference. See the comment in https://issues.apache.org/jira/browse/THRIFT-4484  about `cpp.ref`. Apparently that's now spelled `&` in Thrift IDL. I don't know what effect it has for other languages, the documentation is sparse at best, and doesn't mention this at all.

If this doesn't break other languages I think it's the correct fix for the IDL.